### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2zfx_esr_win32.yml
+++ b/.github/workflows/r2zfx_esr_win32.yml
@@ -1,4 +1,6 @@
 name: r2z Firefox ESR Win32
+permissions:
+  contents: read
 
 on:
   schedule:
@@ -7,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/1](https://github.com/MozillaItalia/pyr2z/security/code-scanning/1)

The recommended fix is to add a `permissions` key at the root of the workflow file (right after the `name:` field and before `on:`), which sets the minimal required permissions for the whole workflow. The safest baseline is `contents: read`. However, steps like uploading GitHub releases (`xresloader/upload-to-github-release`) and committing updates (`stefanzweifel/git-auto-commit-action`) require more than read-only permissions. Therefore, you should:
- Set `permissions` at the workflow root to `contents: read` (applies to all jobs).
- Add more permissive permissions only to jobs that need them, such as granting `contents: write` (for committing/pushing code or modifying contents) and `packages: write` or `actions: write` as appropriate.
- Since this workflow has only one job (`build`), and it performs both releasing and committing, the job-specific `permissions` key must include:
  - `contents: write` (for committing updates and pushing changes)
  - `packages: write` if any packages are published (not obviously needed in this case—note: the release upload action only needs `contents: write`)
- The minimal necessary setting at the job level would be `contents: write`.

Thus, insert a block at the top-level:
```yaml
permissions:
  contents: read
```
and add a job-level override for the `build` job:
```yaml
    permissions:
      contents: write
```
This way, if you add more jobs later, they will by default have only `read` access, and only the job needing `write` access will have it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
