### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2ztb_win64.yml
+++ b/.github/workflows/r2ztb_win64.yml
@@ -1,4 +1,6 @@
 name: r2z Thunderbird Win64
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/7](https://github.com/MozillaItalia/pyr2z/security/code-scanning/7)

The best way to fix this issue is to add an explicit `permissions` block to the workflow. This block should be at the workflow root level, or (optionally) at the job level if jobs have different needs, to ensure permissions are minimized and only those strictly necessary for the workflow are granted. For the steps shown, most interact with the codebase, releases, or Git. To upload a release, the job needs `contents: write` and `packages: write` (if assets are uploaded), and for the auto-commit step, it needs `contents: write`. Add a `permissions` block immediately after the workflow `name`, specifying `contents: write` (and optionally `pull-requests: write` if it interacts with PRs). If you are unsure or want the strictest minimal starting point, begin with `contents: write`. Insert before `on:` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
