### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2ztb_nightly_win64.yml
+++ b/.github/workflows/r2ztb_nightly_win64.yml
@@ -1,4 +1,6 @@
 name: r2z Thunderbird Nightly Win64
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/6](https://github.com/MozillaItalia/pyr2z/security/code-scanning/6)

To fix the problem, we should add a `permissions` block to the workflow at either the root level or the job level. Since this workflow consists of a single job (`build`), either approach is fine, but the most future-proof and standard is to add it at the workflow root so it applies to all jobs except those that explicitly override.  
We should specify the minimum required permissions for this workflow. Looking at the workflow steps:  
- Anything using the `upload-to-github-release` action requires `contents: write` or at least `contents: read, write` to upload release assets.
- The `git-auto-commit-action` requires `contents: write` to push commits.
- If we use "least privilege", and only these two steps require `contents: write`, that's the only permission likely needed (since the other steps are just package installs, actions, etc).  
Therefore, we should add, at the root of the workflow, after the `name:` key and before `on:`, the following block:
```yaml
permissions:
  contents: write
```
If other permissions (like `pull-requests: write`) are required, those should be added, but from the code shown, only `contents: write` is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
