### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2ztb_win32.yml
+++ b/.github/workflows/r2ztb_win32.yml
@@ -1,4 +1,6 @@
 name: r2z Thunderbird Win32
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/12](https://github.com/MozillaItalia/pyr2z/security/code-scanning/12)

The problem should be fixed by adding a `permissions:` block to the workflow. The best approach is to add this block at the workflow root to restrict permissions for all jobs, or add it to individual jobs as needed. For this specific workflow, we should grant only `contents: write` (required for committing and releasing) and, if necessary, `packages: write` or others if used (the provided workflow only needs `contents: write`). Place the following block after the workflow name:

```yaml
permissions:
  contents: write
```

This way, only write access to repository contents is allowed, and other permissions (issues, pull-requests, etc.) are not granted, following the principle of least privilege. Other permissions can be added if future steps require them, but currently `contents: write` covers the file commit and release upload steps.

Edit the top of .github/workflows/r2ztb_win32.yml to insert the block after `name:` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
