### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2zfx_win64.yml
+++ b/.github/workflows/r2zfx_win64.yml
@@ -1,4 +1,6 @@
 name: r2z Firefox Win64
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/9](https://github.com/MozillaItalia/pyr2z/security/code-scanning/9)

To fix this issue, add an explicit `permissions` block to the workflow file to restrict the GITHUB_TOKEN scope to only what is required. The best way is to add the block at the root of the workflow, before the `jobs:` section, unless specific jobs require differing permissions (which isn't shown here). Since this workflow checks out code, commits updates, and uploads releases, it needs `contents: write`. If any jobs need additional permissions (e.g., for issues, pull-requests), those can be added, but that doesn't appear necessary based on the steps shown. Insert the following block after the workflow's `name` and before `on:`:

```yaml
permissions:
  contents: write
```

This provides the least privilege necessary for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
