### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2zfx_win32.yml
+++ b/.github/workflows/r2zfx_win32.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/8](https://github.com/MozillaItalia/pyr2z/security/code-scanning/8)

To resolve the issue, add a `permissions` block limiting the default privileges of the `GITHUB_TOKEN` used by the workflow. Since the workflow performs actions that require write access to both repository content (for commits) and GitHub releases (for uploading release files), the `permissions` block should grant `contents: write` and, because the upload-to-release action may require it, likely `packages: write` as well. It is best to add these at the job level if only this job requires them, or at the root if all jobs would. In this case, adding the following under the `build:` job in `.github/workflows/r2zfx_win32.yml` suffices:

```yaml
permissions:
  contents: write
```

Optionally add `packages: write` if uploading a release asset requires it, but with the provided Actions, `contents: write` covers both uploading release assets and committing to the repo. Thus, under the `build:` job, add:

```yaml
permissions:
  contents: write
```

No additional imports, methods, or definitions are needed; this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
