### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/r2zfx_esr_win64.yml
+++ b/.github/workflows/r2zfx_esr_win64.yml
@@ -1,5 +1,8 @@
 name: r2z Firefox ESR Win64
 
+permissions:
+  contents: write
+
 on:
   schedule:
   - cron: '15 19 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/MozillaItalia/pyr2z/security/code-scanning/10](https://github.com/MozillaItalia/pyr2z/security/code-scanning/10)

To fix the problem, add an explicit `permissions:` block at the workflow root level or within each job that needs elevated permissions. The principle of least privilege should apply: grant only the permissions necessary for the workflow tasks.

- **Where:** At the workflow root, above `jobs:`.
- **How:** Analyze actions.  
  - Creating a release, uploading assets, and committing updates require write access to `contents`.
  - If you do not need to update pull requests, you do not need pull-requests write.
  - For most read-only operations (like checking out code), only `contents: read` is required.
  - Since both release upload and git commit need `contents: write`, this workflow does need `contents: write` (and possibly additional scopes).
- **Best fix:** Add a `permissions:` block at the root, granting only the least permissions required. For these jobs, that means:
  - `contents: write` (required for git commit and uploading release assets).
  - No need to specify other scopes unless found necessary (the workflow does not use discussions, issues, etc.).
- **Implementation:** Insert the block at the top, after defining the name and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
